### PR TITLE
ability	to only	run specified Stream Decks instead of all attached de…

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -15,6 +15,8 @@ argparser.add_argument("--skip-load-hardware-decks", help="Skips initilization/u
 argparser.add_argument("--close-running", help="Close running", action="store_true")
 argparser.add_argument("--data", help="Data path", type=str)
 argparser.add_argument("--change-page", action="append", nargs=2, help="Change the page for a device", metavar=("SERIAL_NUMBER", "PAGE_NAME"))
+argparser.add_argument("--list", default=False, action="store_true", help="List all the detected Stream Decks and exit")
+argparser.add_argument("--paths", default=[], nargs='+', help="Open only the Stream Decks with the given paths (see paths using --list)")
 argparser.add_argument("app_args", nargs="*")
 
 VAR_APP_PATH = os.path.join(os.path.expanduser("~"), ".var", "app", "com.core447.StreamController")

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -80,7 +80,14 @@ class DeckManager:
         self.load_fake_decks()
 
     def load_hardware_decks(self):
-        decks=DeviceManager().enumerate()
+        decks: list[StreamDeck.StreamDeck]=DeviceManager().enumerate()
+        if gl.argparser.parse_args().list:
+            for deck in decks:
+                print(deck.device.path(), deck.deck_type(), deck.product_id())
+            exit(0)
+        paths = gl.argparser.parse_args().paths
+        if paths:
+            decks = [d for d in decks if d.device.path() in paths]
         for deck in decks:
             try:
                 if self.beta_resume_mode:


### PR DESCRIPTION
…cks. achieved by adding `--list` and `--paths` command line arguments.

`--list` lists all the attached	Stream Deck devices with some basic information, including their "paths", and exits `--paths` takes	1 or more paths	(found via `--list`) and filters out paths not specified before	initializing the devices